### PR TITLE
Library list page integration and rendering

### DIFF
--- a/src/components/Library/LibraryItemBuilder.tsx
+++ b/src/components/Library/LibraryItemBuilder.tsx
@@ -8,7 +8,7 @@ interface ItemProps {
 
 const LibraryItemBuilder: React.FunctionComponent<ItemProps> = props => {
   return (
-    <div key={props.item.modular_id}>
+    <div key={props.item.inventory_id}>
       <h3>{props.item.name}</h3>
       {props.item.quantity ? <p>In Stock</p> : <p>Out of Stock</p>}
       {props.item.image_url ? (

--- a/src/pages/library.tsx
+++ b/src/pages/library.tsx
@@ -4,7 +4,7 @@ import {supabase} from '~/lib/supabase';
 import LibraryItemBuilder from '../components/Library/LibraryItemBuilder';
 
 export interface Modular {
-  modular_id: number;
+  inventory_id: number;
   created_at: Date;
   updated_at: Date;
   name: string;


### PR DESCRIPTION
The initial **Library** page currently renders a list of all items in the `modulars` table in Supabase along with details.  

The list contains only two items at this time, but with future plans to add more library items including books and accessories, this page should be updated to display a searchable and filterable list as well as detail page routes for each library item.